### PR TITLE
Update build_install_pyradio.bat

### DIFF
--- a/devel/build_install_pyradio.bat
+++ b/devel/build_install_pyradio.bat
@@ -17,7 +17,7 @@ if exist C:\mplayer (
     set "MPLAYER=C:\mplayer"
     set "MPLAYER_SYSTEM=yes"
 )
-if exist "%USERPROFILE%\mplayer\mplayer.exe" set "MPLAYER="\mplayer"
+if exist "%USERPROFILE%\mplayer\mplayer.exe" set "MPLAYER=%USERPROFILE%\mplayer"
 if exist "%APPDATA%\pyradio\mplayer\mplayer.exe" set "MPLAYER=%APPDATA%\pyradio\mplayer"
 
 


### PR DESCRIPTION
The build script for Windows didn't account for directory names with spaces in them. I've fixed it and tested on my pc